### PR TITLE
Minor fixups

### DIFF
--- a/bin/inject_reindexer
+++ b/bin/inject_reindexer
@@ -5,8 +5,8 @@ require 'elasticsearch'
 require_relative '../tasks/reindexer.rb'
 require_relative '../constants.rb'
 
-source_index = ARGV[0] 
-snapshot     = ARGV[1]
+snapshot     = ARGV[0] 
+source_index = ARGV[1]
 
 Resque.redis = "#{RED_HOST}:6379"
 esclient = Elasticsearch::Client.new host: ES_HOST, request_timeout: 360

--- a/tasks/snapper.rb
+++ b/tasks/snapper.rb
@@ -57,7 +57,8 @@ class Snapper
                                                 snapshot: snapshot,
                                                 body: {
                                                   rename_pattern: "^(.*)$",
-                                                  rename_replacement: "$1-base"
+                                                  rename_replacement: "$1-base",
+                                                  include_global_state: false
                                                 }
     snap_wait(esclient, snapshot)
     cluster_wait(esclient)


### PR DESCRIPTION
Fixes two issues:

1. Swap the arguments on `bin/inject_reindexer` to match the documented values (turns out it was right the first time).
1. Ensure that snapshot-restores don't also restore 'global state', which includes potentially really old and broken templates. An issue when reindexing ES1.x snapshots on ES2.x