### PR TITLE
Merge in es6 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,15 @@
 source 'https://rubygems.org'
 
 # Uncomment this for ES 1.x
-gem 'elasticsearch', '1.1.0'
+#gem 'elasticsearch', '1.1.0'
 # Uncomment this for ES 2.x
 #gem 'elasticsearch', '2.0.2'
+# For ElasticSearch 5.x!
+#gem 'elasticsearch', '5.0.5'
+# For Elasticsearch 6.x!
+gem 'elasticsearch', '6.8.3'
 
 gem 'resque'
 gem 'rake'
 
-ruby '>= 2.2.0'
+ruby '>= 2.5.0'

--- a/bin/inject_reindexer
+++ b/bin/inject_reindexer
@@ -11,7 +11,7 @@ source_index = ARGV[1]
 Resque.redis = "#{RED_HOST}:6379"
 esclient = Elasticsearch::Client.new host: ES_HOST, request_timeout: 360
 
-puts "Attempting to inject a reindexing job for #{source_index} into a snapshot named #{snapshot}."
+puts "Attempting to inject a reindexing job to reindex #{source_index} into a snapshot named #{snapshot}."
 
 if esclient.indices.exists( :index => "#{source_index}-base" )
   puts "Index identified, injecting a reindex job."

--- a/constants.rb
+++ b/constants.rb
@@ -1,19 +1,22 @@
 ## The ElasticSearch host to hit for Elastic operations.
-ES_HOST  = '127.0.0.1'
+ES_HOST  = '192.0.2.199'
 
 ## The name of the snapshot repository you will be performing snapshot
 ## operations on.
-ES_REPO  = 'reindexing_repo'
+ES_REPO = 'logstash-repository'
 
 ## The name of the Redis host used for Resque. It's safe to use your
 ## logstash redis host, if one is used.
-RED_HOST = 'logstash.example.com'
+RED_HOST = 'redis-queue'
 
 ## The regex to use to identify which snapshots in the repo we wish to process.
 ## The default looks for snapshots named like: "logstash-20190801"
 SNAP_REGEX = /^logstash-\d{8}/
 
-## How big the bulk-updates should be to ES. Larger is not always faster,
-## you will probably want to try tuning this.
-ES_BULK_SIZE = 750
+## The target maximum shard-size in bytes. Used to reduce shard-counts
+## of indexes from the "default to 5 shards" days. Will also expand
+## shard-counts for indexes that blew past this size. Elastic recommends
+## keeping this value below 50GB for performance, but you need to test your
+## reindexing to know how much reduction you naturally get.
+SHARD_TARGET = 50*1024*1024*1024
 

--- a/gen_snaplist.rb
+++ b/gen_snaplist.rb
@@ -7,10 +7,10 @@ esclient = Elasticsearch::Client.new host: ES_HOST
 
 raw_snaps  = esclient.snapshot.get repository: ES_REPO, snapshot: '_all'
 red_client = Redis.new(:host => RED_HOST)
-our_snaps  = { }
+our_snaps  = {}
 raw_snaps['snapshots'].each do |snap|
-  if snap['snapshot'] =~ SNAP_REGEX and
-     snap['state'] == 'SUCCESS' and
+  if snap['snapshot'] =~ SNAP_REGEX &&
+     snap['state'] == 'SUCCESS' &&
      snap['indices'].size == 1
     our_snaps[snap['snapshot']] = snap['indices']
   end
@@ -19,6 +19,6 @@ end
 # Get our list of snapshots, and reverse it since it will be popped out
 # stack-style. Should ensure the oldest gets popped first.
 our_snaps.keys.sort.reverse.each do |sn|
-  snap_data = JSON.dump( { 'snapshot'=> sn, 'index' => our_snaps[sn][0] } )
+  snap_data = JSON.dump({ 'snapshot' => sn, 'index' => our_snaps[sn][0] })
   red_client.lpush('reindex_snaplist', snap_data)
 end

--- a/tasks/reindexer.rb
+++ b/tasks/reindexer.rb
@@ -18,9 +18,9 @@ require 'redis'
 #
 # @author Jamie Riedesel <jamie.riedesel@hellosign.com>
 class Reindexer
-  
+
   # The JSON to define a field of type string
-  TYPE_STRING  = {"type"=>"string", "norms"=>{"enabled"=>false}, "fields"=>{"raw"=>{"type"=>"string", "index"=>"not_analyzed", "ignore_above"=>256}}}
+  TYPE_STRING  = {"type"=>"text", "norms"=>false, "fields"=>{"raw"=>{"type"=>"keyword", "ignore_above"=>256}}, "fielddata"=>false}
 
   # The JSON to define a field of type long
   TYPE_LONG    = {"type"=>"long"}
@@ -30,6 +30,62 @@ class Reindexer
 
   # The JSON to define a field of type float
   TYPE_FLOAT   = {"type"=>"float"}
+
+  # The JSON to define a keyword type
+  TYPE_KEYWORD = {"type"=>"keyword"}
+
+  # The JSON to define a text type
+  TYPE_TEXT    = {"type"=>"text", "norms"=>false}
+
+  # The default mapping for ES6. Set number_of_shards and
+  # total_fields.limit to values that make sense for you.
+  DEF_MAPPING  = {
+    "settings" => {
+      "index.number_of_shards"                   => "5",
+      "index.mapping.total_fields.limit"         => "1024"
+    },
+    "mappings" => {
+      "_doc" => {
+        "dynamic_templates" => [
+          {
+            "message_field" => {
+              "match"              => "message",
+              "match_mapping_type" => "string",
+              "mapping"            => {
+                "fielddata" => false,
+                "index"     => "true",
+                "norms"     => false,
+                "type"      => "text"
+              }
+            }
+          },
+          {
+            "string_fields" => {
+              "match"              => "*",
+              "match_mapping_type" => "string",
+              "mapping"            => {
+                "fielddata" => false,
+                "fields"    => {
+                  "raw" => {
+                    "ignore_above" => 256,
+                    "type"         => "keyword"
+                  }
+                },
+                "index"     => "true",
+                "norms"     => false,
+                "type"      => "text"
+              }
+            }
+          }
+        ],
+        "properties" => {
+          "message" => {
+            "type" => "text",
+          }
+        }
+      }
+    }
+  }
 
   @queue = :reindexer
 
@@ -80,21 +136,45 @@ class Reindexer
 
   private
 
-  # Mutates the index mapping to make it ES2.x friendly, and create the
-  # index we're reindexing into; should be edited.
+  # Mutates the index mapping to make it friendly to the next ES version, and
+  # create the index we're reindexing into.
   #
-  # This is the method that performs the mapping mutation. If you are doing an
-  # ES 1.x to ES 2.x upgrade, you will likely need to make changes to the
-  # logic here.
+  # This is the method that performs the mapping mutation.
+  #
+  # * If you are doing an ES 1.x to ES 2.x upgrade, this is where you merge field-types.
+  # * If you are doing an ES 5.x to ES 6.x upgrade, this is where you merge mappings to a single one.
+  #
+  # You will likely need to make changes to the logic here.
+  #
+  # This method is also where you would perform any redactions to your
+  # events, such as removing accidentally logged privacy or health information.
   #
   # @note This function should be edited.
+  #
+  # @note This will remove _default_ mapping-types, which were removed in ES7.
   #
   # @param esclient [Elasticsearch::Client] An inited object of type Elasticsearch::Client
   # @param source [String] The name of the index to pull mappings from.
   # @param target [String] The name of the index to create with the mutated mapping.
   def self.mutate_mapping(esclient, source, target)
-    mapping      = esclient.indices.get_mapping index: source
-    base_mapping = mapping["#{source}"]
+    mapping         = esclient.indices.get_mapping index: source
+    base_mapping    = mapping[source]
+    target_mapping  = DEF_MAPPING
+    source_settings = esclient.indices.get_settings index: source
+
+    index_stats = esclient.indices.stats index: source
+    index_repl  = source_settings[source]['settings']['index']['number_of_replicas'].to_i + 1
+    index_size  = index_stats['_all']['total']['store']['size_in_bytes'].fdiv(index_repl)
+
+    # Shard-limit, we want under SHARD_TARGET sized shards, minimum 1.
+    target_mapping['settings']['index.number_of_shards'] = index_size.fdiv(SHARD_TARGET).ceil
+    # Field-limit, definitely copy this
+    target_mapping['settings']['index.mapping.total_fields.limit'] = source_settings[source]['settings']['index']['mapping']['total_fields']['limit']
+    # target-allocation, make sure things stay on
+    # wherever they're supposed to.
+    if source_settings[source]['settings']['index'].keys.include?('routing')
+      target_mapping['settings']['index.routing'] = source_settings[source]['settings']['index']['routing']
+    end
 
     # This is where you put your schema conversions. Here are some examples:
     #
@@ -107,9 +187,46 @@ class Reindexer
     ## if base_mapping['mappings']['cheese_callback'] != nil
     ##   base_mapping['mappings']['cheese_callback']['properties']['timestamp'] = TYPE_STRING
     ## end
-    
+
+    # Force everything to the '_doc' doctype. ES6 restriction. For the ES7
+    # reindexing, we can likely avoid the subtype loop entirely.
+    base_mapping['mappings'].each_key do |subtype|
+      if subtype != '_default_'
+        base_mapping['mappings'][subtype]['properties'].each_key do |type_key|
+          # Due to ES2+ restrictions, there shouldn't be type-collisions between mappings.
+          if not target_mapping['mappings']['_doc']['properties'].has_key?(type_key)
+            target_mapping['mappings']['_doc']['properties'][type_key] = base_mapping['mappings'][subtype]['properties'][type_key]
+          end
+          if target_mapping['mappings']['_doc']['properties'][type_key]['type'] == "string"
+            # 'string' --> 'text' conversion, not needed for ES7.
+            target_mapping['mappings']['_doc']['properties'][type_key] == TYPE_STRING
+          elsif target_mapping['mappings']['_doc']['properties'][type_key]['type'] == "double"
+            # 'double' --> 'float' conversion, to save space.
+            target_mapping['mappings']['_doc']['properties'][type_key] == TYPE_FLOAT
+          end
+        end
+      end
+    end
+
+    # This is where you could perform redactions as part of reprocessing.
+    # Perform changes on the source index before we start reindexing, to
+    # ensure the target index has no trace of the removed/redacted events.
+
+    # Example of deleting everything containing a key string, such as
+    # removing privacy information. This example removes events that look like:
+    #
+    #   Created account hithere@example.com in zone 119291
+    #
+    #esclient.delete_by_query index: source, wait_for_completion: true, body: {
+    #  "query": {
+    #    "query_string": {
+    #      "query": 'message:"Created account for" AND message:"in zone"'
+    #    }
+    #  }
+    #}
+
     # Create the index using the revised mapping.
-    index_create = esclient.indices.create index: target, body: base_mapping
+    index_create = esclient.indices.create index: target, body: target_mapping
     Resque::Logging.info("Created target index, #{target}.")
   end
 
@@ -137,33 +254,53 @@ class Reindexer
       source_index = "#{index}-base"
       target_index = index
     end
-    rs = esclient.search index: source_index,
-                         search_type: 'scan',
-                         scroll: '2m',
-                         size: ES_BULK_SIZE
-    loop do
-      us = []
-      rs = esclient.scroll(scroll_id: rs['_scroll_id'], scroll: '2m')
-      break if rs['hits']['hits'].empty?
-      rs['hits']['hits'].each do |doc|
-        us.push( index: { _index: target_index, _type: doc['_type'], _id: doc['_id'],
-                           data: doc['_source'] } )
-      end
-      esclient.bulk body: us
-    end
+    # Force-flush to commit the translog. If we don't do this, redacted
+    # documents may still be present after reindexing.
+    esclient.indices.flush index: source_index
+    # Get shard-count:
+    target_settings = esclient.indices.get_settings index: target_index
+    shard_count = target_settings[target_index]['settings']['index']['number_of_shards'].to_i
+    # Uses the Reindexing API to perform the index, it's a task.
+    reindex_task = esclient.reindex slices: 'auto', wait_for_completion: false, body: {
+      source: {
+        index: source_index
+      },
+      dest: {
+        index: target_index
+      },
+      script: {
+        source: 'ctx._type = params.type',
+        params: {
+          type: '_doc'
+        },
+        lang: 'painless'
+      }
+    }
+    log_msg = "Waiting for reindex of #{source_index} into #{target_index} through #{reindex_task['task']} and #{shard_count} shards."
     if testmode
-      puts("Terminating without snapshot. Go check your work.")
+      puts(log_msg)
+    else
+      Resque::Logging.info(log_msg)
+    end
+    task_status = esclient.tasks.get task_id: reindex_task['task']
+    while task_status['completed'] == false
+      sleep 10
+      task_status = esclient.tasks.get task_id: reindex_task['task']
+    end
+
+    if testmode
+      puts('Terminating without snapshot. Go check your work.')
     else
       Resque::Logging.info("Finished reindexing of #{index}.")
-      Resque.enqueue( Snapper, "snapshot", "#{snapshot}", "#{index}" )
+      Resque.enqueue( Snapper, 'snapshot', snapshot, index )
     end
   end
 
   # Pops off the next snapshot from the redis-list and submits it for restore.
   def self.push_new()
-    redball   = Redis.new( :host => "#{RED_HOST}" )
+    redball   = Redis.new( :host => RED_HOST )
     snap_data = JSON.parse( redball.lpop( 'reindex_snaplist' ) )
-    Resque.enqueue( Snapper, "restore", "#{snap_data['snapshot']}", "#{snap_data['index']}" ) 
+    Resque.enqueue( Snapper, 'restore', snap_data['snapshot'], snap_data['index'] )
   end
 
 end


### PR DESCRIPTION
Adds support for reindexing on Elasticsearch 6, which uses the reindexing API instead of the brute-force method we used for ES2.